### PR TITLE
Add and  RPC example using  direct reply queue

### DIFF
--- a/examples/rpc/README.md
+++ b/examples/rpc/README.md
@@ -1,0 +1,32 @@
+RPC example
+===
+
+This example demonstrates how to set up a simple RPC (Remote Procedure Call) server and client using [Direct reply to feature](https://www.rabbitmq.com/docs/direct-reply-to). 
+The example is very basic the correlation id is set but not used to match responses to requests.
+
+Setup
+---
+
+To run this example, you need to have RabbitMQ >=4.2 server running locally.
+Then run the python scripts in separate terminal windows.
+```bash
+$ python3 server.py
+connection_consumer to amqp server
+Responder listening on address: /queues/rpc_queue
+```
+
+Then in another terminal window run:
+```bash
+$ python3 client.py
+connection_consumer to amqp server
+connected both publisher and consumer
+consumer reply address is /queues/amq.rabbitmq.reply-to.g1h2AA5yZXBseUA2ODc4MTMzNAAAcEoAAAAAaS8eQg%3D%
+```
+
+The `rpc_queue` is the queue where the server listens for incoming RPC requests.</br>
+The `amq.rabbitmq.reply-to.g1h2AA...` is a special direct-reply-to queue used by the client to receive responses.
+
+Use standard queues for reply 
+===
+
+If you want to use standard queues for replies instead of the direct-reply-to feature.

--- a/examples/rpc/README.md
+++ b/examples/rpc/README.md
@@ -11,14 +11,8 @@ To run this example, you need to have RabbitMQ >=4.2 server running locally.
 Then run the python scripts in separate terminal windows.
 ```bash
 $ python3 server.py
-connection_consumer to amqp server
+Connecting consumer to AMQP server
 Responder listening on address: /queues/rpc_queue
-```
-
-Then in another terminal window run:
-```bash
-$ python3 client.py
-connection_consumer to amqp server
 connected both publisher and consumer
 consumer reply address is /queues/amq.rabbitmq.reply-to.g1h2AA5yZXBseUA2ODc4MTMzNAAAcEoAAAAAaS8eQg%3D%
 ```

--- a/examples/rpc/README.md
+++ b/examples/rpc/README.md
@@ -23,4 +23,14 @@ The `amq.rabbitmq.reply-to.g1h2AA...` is a special direct-reply-to queue used by
 Use standard queues for reply 
 ===
 
-If you want to use standard queues for replies instead of the direct-reply-to feature.
+If you want to use standard queues for replies instead of the direct-reply-to feature is enough change the consumer declaration:
+
+```python
+queue_name = "rpc_reply_queue"
+management.declare_queue(QuorumQueueSpecification(name=queue_name))
+
+consumer = await connection_consumer.consumer(
+        destination=AddressHelper.queue_address(queue_name))
+```
+
+You should use [Classic Queues](https://www.rabbitmq.com/docs/classic-queues) or [Quorum Queues](https://www.rabbitmq.com/docs/quorum-queues).

--- a/examples/rpc/client.py
+++ b/examples/rpc/client.py
@@ -13,8 +13,12 @@ class Requester:
     def __init__(self, request_queue_name: str, environment: Environment):
         self.connection = environment.connection()
         self.connection.dial()
-        self.publisher = self.connection.publisher(AddressHelper.queue_address(request_queue_name))
-        self.consumer = self.connection.consumer(consumer_options=DirectReplyToConsumerOptions())
+        self.publisher = self.connection.publisher(
+            AddressHelper.queue_address(request_queue_name)
+        )
+        self.consumer = self.connection.consumer(
+            consumer_options=DirectReplyToConsumerOptions()
+        )
         print("connected both publisher and consumer")
         print("consumer reply address is {}".format(self.consumer.address))
 
@@ -35,9 +39,15 @@ def main() -> None:
         request_body = "hello {}".format(i)
         print("******************************************************")
         print("Sending request: {}".format(request_body))
-        response_message = responder.send_request(request_body=request_body, correlation_id=correlation_id)
+        response_message = responder.send_request(
+            request_body=request_body, correlation_id=correlation_id
+        )
         response_body = Converter.bytes_to_string(response_message.body)
-        print("Received response: {} - correlation_id: {}".format(response_body, response_message.correlation_id))
+        print(
+            "Received response: {} - correlation_id: {}".format(
+                response_body, response_message.correlation_id
+            )
+        )
         print("------------------------------------------------------")
         time.sleep(1)
 

--- a/examples/rpc/client.py
+++ b/examples/rpc/client.py
@@ -33,13 +33,13 @@ class Requester:
 def main() -> None:
     print("connection_consumer to amqp server")
     environment = Environment(uri="amqp://guest:guest@localhost:5672/")
-    responder = Requester(request_queue_name="rpc_queue", environment=environment)
+    requester = Requester(request_queue_name="rpc_queue", environment=environment)
     for i in range(10):
         correlation_id = str(i)
         request_body = "hello {}".format(i)
         print("******************************************************")
         print("Sending request: {}".format(request_body))
-        response_message = responder.send_request(
+        response_message = requester.send_request(
             request_body=request_body, correlation_id=correlation_id
         )
         response_body = Converter.bytes_to_string(response_message.body)

--- a/examples/rpc/client.py
+++ b/examples/rpc/client.py
@@ -1,0 +1,46 @@
+import time
+
+from rabbitmq_amqp_python_client import (
+    AddressHelper,
+    Converter,
+    DirectReplyToConsumerOptions,
+    Environment,
+    Message,
+)
+
+
+class Requester:
+    def __init__(self, request_queue_name: str, environment: Environment):
+        self.connection = environment.connection()
+        self.connection.dial()
+        self.publisher = self.connection.publisher(AddressHelper.queue_address(request_queue_name))
+        self.consumer = self.connection.consumer(consumer_options=DirectReplyToConsumerOptions())
+        print("connected both publisher and consumer")
+        print("consumer reply address is {}".format(self.consumer.address))
+
+    def send_request(self, request_body: str, correlation_id: str) -> Message:
+        message = Message(body=Converter.string_to_bytes(request_body))
+        message.reply_to = self.consumer.address
+        message.correlation_id = correlation_id
+        self.publisher.publish(message=message)
+        return self.consumer.consume()
+
+
+def main() -> None:
+    print("connection_consumer to amqp server")
+    environment = Environment(uri="amqp://guest:guest@localhost:5672/")
+    responder = Requester(request_queue_name="rpc_queue", environment=environment)
+    for i in range(10):
+        correlation_id = str(i)
+        request_body = "hello {}".format(i)
+        print("******************************************************")
+        print("Sending request: {}".format(request_body))
+        response_message = responder.send_request(request_body=request_body, correlation_id=correlation_id)
+        response_body = Converter.bytes_to_string(response_message.body)
+        print("Received response: {} - correlation_id: {}".format(response_body, response_message.correlation_id))
+        print("------------------------------------------------------")
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rpc/client.py
+++ b/examples/rpc/client.py
@@ -31,7 +31,7 @@ class Requester:
 
 
 def main() -> None:
-    print("connection_consumer to amqp server")
+    print("Connecting to AMQP server")
     environment = Environment(uri="amqp://guest:guest@localhost:5672/")
     requester = Requester(request_queue_name="rpc_queue", environment=environment)
     for i in range(10):

--- a/examples/rpc/server.py
+++ b/examples/rpc/server.py
@@ -13,9 +13,6 @@ from rabbitmq_amqp_python_client import (
     QuorumQueueSpecification,
 )
 
-MESSAGES_TO_PUBLISH = 200
-
-
 # create a responder
 
 

--- a/examples/rpc/server.py
+++ b/examples/rpc/server.py
@@ -93,7 +93,7 @@ def create_connection(environment: Environment) -> Connection:
 
 
 def main() -> None:
-    print("connection_consumer to amqp server")
+    print("Connecting consumer to AMQP server")
     environment = Environment(uri="amqp://guest:guest@localhost:5672/")
     responder = Responder(request_queue_name="rpc_queue", environment=environment)
     responder.start()

--- a/examples/rpc/server.py
+++ b/examples/rpc/server.py
@@ -51,7 +51,7 @@ class Responder:
             elif status.remote_state == OutcomeState.RELEASED:
                 print("message not routed")
             elif status.remote_state == OutcomeState.REJECTED:
-                print("message not rejected")
+                print("message rejected")
 
             self.delivery_context.accept(event)
             print("------------------------------------------------------")

--- a/examples/rpc/server.py
+++ b/examples/rpc/server.py
@@ -1,0 +1,98 @@
+# type: ignore
+
+
+from rabbitmq_amqp_python_client import (
+    AddressHelper,
+    AMQPMessagingHandler,
+    Connection,
+    Converter,
+    Environment,
+    Event,
+    Message,
+    OutcomeState,
+    QuorumQueueSpecification,
+)
+
+MESSAGES_TO_PUBLISH = 200
+
+
+# create a responder
+
+class Responder:
+    class ResponderMessageHandler(AMQPMessagingHandler):
+
+        def __init__(self):
+            super().__init__()
+            self._publisher = None
+
+        def set_publisher(self, publisher):
+            self._publisher = publisher
+
+        def on_amqp_message(self, event: Event):
+            # process the message and create a response
+            print("******************************************************")
+            print("received message: {} ".format(Converter.bytes_to_string(event.message.body)))
+            response_body = Converter.bytes_to_string(
+                event.message.body) + "-from the server"
+            response_message = Message(
+                body=Converter.string_to_bytes(response_body))
+            # publish response to the reply_to address with the same correlation_id
+            response_message.correlation_id = event.message.correlation_id
+            response_message.address = event.message.reply_to
+            print("sending back: {} ".format(response_body))
+            status = self._publisher.publish(
+                message=response_message
+            )
+            if status.remote_state == OutcomeState.ACCEPTED:
+                print("message accepted to {}".format(response_message.address))
+            elif status.remote_state == OutcomeState.RELEASED:
+                print("message not routed")
+            elif status.remote_state == OutcomeState.REJECTED:
+                print("message not rejected")
+
+            self.delivery_context.accept(event)
+            print("------------------------------------------------------")
+
+    def __init__(self, request_queue_name: str, environment: Environment):
+        self.request_queue_name = request_queue_name
+        self.connection = None
+        self.consumer = None
+        self.publisher = None
+        self._environment = environment
+
+    def start(self):
+        self.connection = self._environment.connection()
+        self.connection.dial()
+        self.connection.management().delete_queue(self.request_queue_name)
+        self.connection.management().declare_queue(
+            queue_specification=QuorumQueueSpecification(self.request_queue_name))
+        self.publisher = self.connection.publisher()
+        handler = self.ResponderMessageHandler()
+        handler.set_publisher(self.publisher)
+
+        self.consumer = self.connection.consumer(destination=AddressHelper.queue_address(self.request_queue_name),
+                                                 message_handler=handler
+                                                 )
+        addr = self.consumer.address
+        print("Responder listening on address: {}".format(addr))
+        try:
+            self.consumer.run()
+        except KeyboardInterrupt:
+            print("Responder stopping...")
+
+
+def create_connection(environment: Environment) -> Connection:
+    connection = environment.connection()
+    connection.dial()
+    return connection
+
+
+def main() -> None:
+    print("connection_consumer to amqp server")
+    environment = Environment(uri="amqp://guest:guest@localhost:5672/")
+    responder = Responder(request_queue_name="rpc_queue", environment=environment)
+    responder.start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a simple RPC (Remote Procedure Call) example demonstrating the direct reply-to feature in RabbitMQ. The implementation includes a server that processes requests from a queue and sends responses back using the client's reply-to address, and a client that sends requests and waits for responses using RabbitMQ's special direct-reply-to queue.

Key changes:

- Server implementation that listens on a quorum queue, processes incoming RPC requests, and sends responses back to the reply-to address

- Client implementation using DirectReplyToConsumerOptions to receive responses without declaring a named queue

- Documentation explaining the RPC pattern and setup instructions
