### PR TITLE
Rename Consumer Feature to Consumer SettleStrategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@ Located in `rabbitmq_amqp_python_client/entities.py`:
 - **`StreamConsumerOptions`**: Configuration for stream consumers (supports `offset_specification` as `OffsetSpecification`, `int`, or `datetime`)
 - **`StreamFilterOptions`**: Filter options for stream consumers
 - **`OffsetSpecification`**: Enum for stream offset positions (first, next, last, timestamp)
-- **`ConsumerOptions`**: Base class for consumer options
-- **`DirectReplyToConsumerOptions`**: Options for direct reply-to consumers
+- **`ConsumerOptions`**: Configuration for FIFO (Classic/Quorum) consumers; uses `settle_strategy` (ConsumerSettleStrategy) for uniform AMQP 1.0 client interface
+- **`ConsumerSettleStrategy`**: Enum for settle strategy: ExplicitSettle, DirectReplyTo, PreSettled
 - Queue/Exchange specifications: `QuorumQueueSpecification`, `StreamSpecification`, `ExchangeSpecification`, etc.
 
 ## Project Structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed (breaking)
+- **Consumer options aligned with uniform AMQP 1.0 clients interface** (cf. rabbitmq-amqp-dotnet-client [#144](https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client/pull/144)):
+  - Renamed `ConsumerFeature` to `ConsumerSettleStrategy`.
+  - Renamed enum values: `DefaultSettle` → `ExplicitSettle`, `Presettled` → `PreSettled` (DirectReplyTo unchanged).
+  - `ConsumerOptions` now takes `settle_strategy: ConsumerSettleStrategy` instead of `feature: ConsumerFeature`. Use `ConsumerOptions(settle_strategy=ConsumerSettleStrategy.ExplicitSettle)` (default), `ConsumerSettleStrategy.DirectReplyTo`, or `ConsumerSettleStrategy.PreSettled`.
+
 ## [[0.4.1](https://github.com/rabbitmq/rabbitmq-amqp-python-client/releases/tag/v0.4.1)]
 
 ## 0.4.1 - 2025-01-14

--- a/examples/direct_reply_queue/direct_reply_to.py
+++ b/examples/direct_reply_queue/direct_reply_to.py
@@ -4,8 +4,8 @@
 from rabbitmq_amqp_python_client import (
     AMQPMessagingHandler,
     Connection,
-    ConsumerFeature,
     ConsumerOptions,
+    ConsumerSettleStrategy,
     Converter,
     Environment,
     Event,
@@ -59,7 +59,9 @@ def main() -> None:
     connection_consumer = create_connection(environment)
     consumer = connection_consumer.consumer(
         message_handler=MyMessageHandler(),
-        consumer_options=ConsumerOptions(ConsumerFeature.DirectReplyTo),
+        consumer_options=ConsumerOptions(
+            settle_strategy=ConsumerSettleStrategy.DirectReplyTo
+        ),
     )
     addr = consumer.address
     print("connecting to address: {}".format(addr))

--- a/examples/pre_settled_consumer/example_pre_settled_consumer.py
+++ b/examples/pre_settled_consumer/example_pre_settled_consumer.py
@@ -7,13 +7,13 @@ examples/pre_settled_consumer/example_pre_settled_consumer.py
 This example shows how to use ConsumerOptions with pre-settled
 to enable at-most-once delivery semantics for FIFO (Classic and Quorum) queues.
 
-When ConsumerFeature.Presettled:
+When ConsumerSettleStrategy.PreSettled:
 - Messages are automatically settled when received
 - Messages cannot be redelivered if processing fails
 - Suitable for use cases where message loss is acceptable
   (e.g., metrics, logs, sensor data)
 
-When ConsumerFeature.Default:
+When ConsumerSettleStrategy.ExplicitSettle:
 - Messages require explicit acknowledgment
 - Messages can be redelivered if not acknowledged
 - Provides at-least-once delivery semantics
@@ -24,15 +24,13 @@ from rabbitmq_amqp_python_client import (
     AMQPMessagingHandler,
     Connection,
     ConsumerOptions,
+    ConsumerSettleStrategy,
     Converter,
     Environment,
     Event,
     Message,
     OutcomeState,
     QuorumQueueSpecification,
-)
-from rabbitmq_amqp_python_client.entities import (
-    ConsumerFeature,
 )
 
 MESSAGES_TO_PUBLISH = 50
@@ -105,15 +103,17 @@ def main() -> None:
     publisher.close()
 
     print("\n" + "=" * 60)
-    print("Creating FIFO consumer with pre_settled=True")
+    print("Creating FIFO consumer with PreSettled strategy")
     print("(at-most-once delivery semantics)")
     print("=" * 60)
 
-    # Create consumer with pre_settled=True
+    # Create consumer with PreSettled settle strategy
     consumer = connection.consumer(
         destination=addr_queue,
         message_handler=MyMessageHandler(),
-        consumer_options=ConsumerOptions(ConsumerFeature.Presettled),
+        consumer_options=ConsumerOptions(
+            settle_strategy=ConsumerSettleStrategy.PreSettled
+        ),
     )
 
     print("\nStarting consumer - press Ctrl+C to stop...")

--- a/examples/rpc/client.py
+++ b/examples/rpc/client.py
@@ -2,8 +2,8 @@ import time
 
 from rabbitmq_amqp_python_client import (
     AddressHelper,
-    ConsumerFeature,
     ConsumerOptions,
+    ConsumerSettleStrategy,
     Converter,
     Environment,
     Message,
@@ -18,7 +18,9 @@ class Requester:
             AddressHelper.queue_address(request_queue_name)
         )
         self.consumer = self.connection.consumer(
-            consumer_options=ConsumerOptions(feature=ConsumerFeature.DirectReplyTo)
+            consumer_options=ConsumerOptions(
+                settle_strategy=ConsumerSettleStrategy.DirectReplyTo
+            )
         )
         print("connected both publisher and consumer")
         print("consumer reply address is {}".format(self.consumer.address))

--- a/rabbitmq_amqp_python_client/__init__.py
+++ b/rabbitmq_amqp_python_client/__init__.py
@@ -14,8 +14,8 @@ from .connection import Connection
 from .consumer import Consumer
 from .entities import (
     AbcConsumerOptions,
-    ConsumerFeature,
     ConsumerOptions,
+    ConsumerSettleStrategy,
     ExchangeCustomSpecification,
     ExchangeSpecification,
     ExchangeToExchangeBindingSpecification,
@@ -74,7 +74,7 @@ __all__ = [
     "ExchangeSpecification",
     "QuorumQueueSpecification",
     "ClassicQueueSpecification",
-    "ConsumerFeature",
+    "ConsumerSettleStrategy",
     "StreamSpecification",
     "ExchangeToQueueBindingSpecification",
     "ExchangeToExchangeBindingSpecification",

--- a/tests/asyncio/test_consumer.py
+++ b/tests/asyncio/test_consumer.py
@@ -5,8 +5,8 @@ from rabbitmq_amqp_python_client import (
     ArgumentOutOfRangeException,
     AsyncConnection,
     AsyncEnvironment,
-    ConsumerFeature,
     ConsumerOptions,
+    ConsumerSettleStrategy,
     QuorumQueueSpecification,
 )
 from rabbitmq_amqp_python_client.utils import Converter
@@ -397,7 +397,9 @@ async def test_async_CQ_consumer_without_presettled(async_connection: AsyncConne
     await async_publish_messages(async_connection, messages_to_send, queue_name)
     consumer = await async_connection.consumer(
         destination=addr_queue,
-        consumer_options=ConsumerOptions(feature=ConsumerFeature.DefaultSettle),
+        consumer_options=ConsumerOptions(
+            settle_strategy=ConsumerSettleStrategy.ExplicitSettle
+        ),
     )
     consumed = 0
     for i in range(messages_to_send):
@@ -426,7 +428,9 @@ async def test_async_CQ_consumer_with_presettled(async_connection: AsyncConnecti
     await async_publish_messages(async_connection, messages_to_send, queue_name)
     consumer = await async_connection.consumer(
         destination=addr_queue,
-        consumer_options=ConsumerOptions(feature=ConsumerFeature.Presettled),
+        consumer_options=ConsumerOptions(
+            settle_strategy=ConsumerSettleStrategy.PreSettled
+        ),
     )
     consumed = 0
     for i in range(messages_to_send):

--- a/tests/direct_reply_to/test_direct_reply.py
+++ b/tests/direct_reply_to/test_direct_reply.py
@@ -1,7 +1,7 @@
 from rabbitmq_amqp_python_client import (
     Connection,
-    ConsumerFeature,
     ConsumerOptions,
+    ConsumerSettleStrategy,
     Converter,
     Environment,
     OutcomeState,
@@ -11,7 +11,9 @@ from rabbitmq_amqp_python_client.qpid.proton import Message
 
 def test_consumer_create_reply_name(connection: Connection) -> None:
     consumer = connection.consumer(
-        consumer_options=ConsumerOptions(feature=ConsumerFeature.DirectReplyTo)
+        consumer_options=ConsumerOptions(
+            settle_strategy=ConsumerSettleStrategy.DirectReplyTo
+        )
     )
     assert "/queues/amq.rabbitmq.reply-to." in consumer.address
 
@@ -28,7 +30,9 @@ def test_direct_reply_to_send_and_receive(environment: Environment) -> None:
     # Create a consumer using DirectReplyTo feature
     consumer = create_connection(environment).consumer(
         credit=100,
-        consumer_options=ConsumerOptions(feature=ConsumerFeature.DirectReplyTo),
+        consumer_options=ConsumerOptions(
+            settle_strategy=ConsumerSettleStrategy.DirectReplyTo
+        ),
     )
 
     # Get the queue address from the consumer

--- a/tests/test_settled_consumer.py
+++ b/tests/test_settled_consumer.py
@@ -4,8 +4,8 @@ from rabbitmq_amqp_python_client import (  # Environment,
     AddressHelper,
     AMQPMessagingHandler,
     Connection,
-    ConsumerFeature,
     ConsumerOptions,
+    ConsumerSettleStrategy,
     QuorumQueueSpecification,
 )
 from rabbitmq_amqp_python_client.utils import Converter
@@ -24,7 +24,10 @@ def test_fifo_consumer_without_presettled(connection: Connection) -> None:
 
     addr_queue = AddressHelper.queue_address(queue_name)
     consumer = connection.consumer(
-        addr_queue, consumer_options=ConsumerOptions(feature=ConsumerFeature.DefaultSettle)
+        addr_queue,
+        consumer_options=ConsumerOptions(
+            settle_strategy=ConsumerSettleStrategy.ExplicitSettle
+        ),
     )
 
     consumed = 0
@@ -92,7 +95,9 @@ def test_fifo_consumer_with_presettled(connection: Connection) -> None:
     try:
         consumer = connection.consumer(
             addr_queue,
-            consumer_options=ConsumerOptions(feature=ConsumerFeature.Presettled),
+            consumer_options=ConsumerOptions(
+                settle_strategy=ConsumerSettleStrategy.PreSettled
+            ),
             message_handler=MyMessagePresettledHandler(),
         )
         consumer.run()


### PR DESCRIPTION
This PR aligns the Python client’s consumer option names with those of other AMQP 1.0 clients by renaming ConsumerFeature to ConsumerSettleStrategy, renaming enum values, and updating call sites across the codebase (library exports, tests, and examples).

Changes:

* Rename ConsumerFeature → ConsumerSettleStrategy and update enum values (DefaultSettle → ExplicitSettle, Presettled → PreSettled).
* Update ConsumerOptions to accept settle_strategy instead of feature, and adjust internal checks accordingly.
* Update tests/examples/docs and add a breaking-change note in CHANGELOG.md.