### PR TITLE
Allow callers to supply SASL credentials directly

### DIFF
--- a/rabbitmq_amqp_python_client/asyncio/connection.py
+++ b/rabbitmq_amqp_python_client/asyncio/connection.py
@@ -57,6 +57,8 @@ class AsyncConnection:
         ] = None,
         oauth2_options: Optional[OAuth2Options] = None,
         recovery_configuration: RecoveryConfiguration = RecoveryConfiguration(),
+        username: Optional[str] = None,
+        password: Optional[str] = None,
     ):
         """
         Initialize AsyncConnection.
@@ -67,6 +69,8 @@ class AsyncConnection:
             ssl_context: Optional SSL/TLS configuration
             oauth2_options: Optional OAuth2 configuration
             recovery_configuration: Configuration for automatic recovery
+            username: username for authentication
+            password: password for authentication
 
         Raises:
             ValidationCodeException: If recovery configuration is invalid
@@ -77,6 +81,8 @@ class AsyncConnection:
             ssl_context=ssl_context,
             oauth2_options=oauth2_options,
             recovery_configuration=recovery_configuration,
+            username=username,
+            password=password,
         )
         self._connection_lock = asyncio.Lock()
         self._async_publishers: list[AsyncPublisher] = []

--- a/rabbitmq_amqp_python_client/asyncio/environment.py
+++ b/rabbitmq_amqp_python_client/asyncio/environment.py
@@ -43,6 +43,8 @@ class AsyncEnvironment:
         ] = None,
         oauth2_options: Optional[OAuth2Options] = None,
         recovery_configuration: RecoveryConfiguration = RecoveryConfiguration(),
+        username: Optional[str] = None,
+        password: Optional[str] = None,
     ):
         """
         Initialize AsyncEnvironment.
@@ -53,6 +55,8 @@ class AsyncEnvironment:
             ssl_context: SSL configuration for secure connections
             oauth2_options: OAuth2 options for authentication
             recovery_configuration: Configuration for connection recovery
+            username: username for authentication
+            password: password for authentication
 
         Raises:
             ValueError: If both 'uri' and 'uris' are specified or if neither is specified.
@@ -69,6 +73,8 @@ class AsyncEnvironment:
         self._ssl_context = ssl_context
         self._oauth2_options = oauth2_options
         self._recovery_configuration = recovery_configuration
+        self._username = username
+        self._password = password
         self._connections: list[AsyncConnection] = []
         self._connections_lock = asyncio.Lock()
 
@@ -97,6 +103,8 @@ class AsyncEnvironment:
                 ssl_context=self._ssl_context,
                 oauth2_options=self._oauth2_options,
                 recovery_configuration=self._recovery_configuration,
+                username=self._username,
+                password=self._password,
             )
             logger.debug("AsyncEnvironment: Creating new async connection")
             self._connections.append(connection)

--- a/rabbitmq_amqp_python_client/connection.py
+++ b/rabbitmq_amqp_python_client/connection.py
@@ -70,6 +70,8 @@ class Connection:
         ] = None,
         oauth2_options: Optional[OAuth2Options] = None,
         recovery_configuration: RecoveryConfiguration = RecoveryConfiguration(),
+        username: Optional[str] = None,
+        password: Optional[str] = None,
     ):
         """
          Initialize a new Connection instance.
@@ -79,6 +81,8 @@ class Connection:
              uris: List of URIs for multi-node setup
              ssl_context: SSL configuration for secure connections
              reconnect: Ability to automatically reconnect in case of disconnections from the server
+             username: username for authentication
+             password: password for authentication
 
         Raises:
              ValueError: If neither uri nor uris is provided
@@ -103,6 +107,8 @@ class Connection:
         self._publishers: list[Publisher] = []
         self._consumers: list[Consumer] = []
         self._oauth2_options = oauth2_options
+        self._explicit_username: Optional[str] = username
+        self._explicit_password: Optional[str] = password
 
         # Some recovery_configuration validation
         if recovery_configuration.back_off_reconnect_interval < timedelta(seconds=1):
@@ -147,6 +153,11 @@ class Connection:
             self._user = "no"
             self._password = self._oauth2_options.token
             self._mechs = "PLAIN"
+        elif (
+            self._explicit_username is not None and self._explicit_password is not None
+        ):
+            self._user = self._explicit_username
+            self._password = self._explicit_password
 
         if self._recovery_configuration.active_recovery is False:
             self._conn = BlockingConnection(

--- a/rabbitmq_amqp_python_client/environment.py
+++ b/rabbitmq_amqp_python_client/environment.py
@@ -43,6 +43,8 @@ class Environment:
         ] = None,
         oauth2_options: Optional[OAuth2Options] = None,
         recovery_configuration: RecoveryConfiguration = RecoveryConfiguration(),
+        username: Optional[str] = None,
+        password: Optional[str] = None,
     ):
         """
         Initialize a new Environment instance.
@@ -54,6 +56,8 @@ class Environment:
             uris: List of URIs for multi-node setup
             ssl_context: SSL configuration for secure connections
             on_disconnection_handler: Callback for handling disconnection events
+            username: username for authentication
+            password: password for authentication
 
         """
         if uri is not None and uris is not None:
@@ -68,6 +72,8 @@ class Environment:
         self._recovery_configuration = recovery_configuration
         self._connections: list[Connection] = []
         self._oauth2_options = oauth2_options
+        self._username = username
+        self._password = password
 
     def connection(
         self,
@@ -94,6 +100,8 @@ class Environment:
             ssl_context=self._ssl_context,
             oauth2_options=self._oauth2_options,
             recovery_configuration=self._recovery_configuration,
+            username=self._username,
+            password=self._password,
         )
         logger.debug("Environment: Creating and returning a new connection")
         self._connections.append(connection)

--- a/tests/asyncio/test_connection.py
+++ b/tests/asyncio/test_connection.py
@@ -260,3 +260,33 @@ async def test_async_connection_vhost_not_exists() -> None:
     with pytest.raises(ConnectionException):
         connection = await environment.connection()
         await connection.dial()
+
+
+@pytest.mark.asyncio
+async def test_async_connection_username_password() -> None:
+    environment = AsyncEnvironment(
+        uri="amqp://localhost:5672/",
+        username="guest",
+        password="guest",
+    )
+    connection = await environment.connection()
+    await connection.dial()
+    management = await connection.management()
+    await management.declare_queue(
+        QuorumQueueSpecification(name="test-queue-user-pass")
+    )
+    await management.delete_queue("test-queue-user-pass")
+    await management.close()
+    await environment.close()
+
+
+@pytest.mark.asyncio
+async def test_async_connection_username_password_wrong_credentials() -> None:
+    environment = AsyncEnvironment(
+        uri="amqp://localhost:5672/",
+        username="guest",
+        password="wrongpassword",
+    )
+    connection = await environment.connection()
+    with pytest.raises(ConnectionException):
+        await connection.dial()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -272,3 +272,29 @@ def test_connection_vhost_not_exists() -> None:
         exception = True
 
     assert exception is True
+
+
+def test_connection_username_password() -> None:
+    environment = Environment(
+        uri="amqp://localhost:5672/",
+        username="guest",
+        password="guest",
+    )
+    connection = environment.connection()
+    connection.dial()
+    management = connection.management()
+    management.declare_queue(QuorumQueueSpecification(name="test-queue-user-pass"))
+    management.delete_queue("test-queue-user-pass")
+    management.close()
+    environment.close()
+
+
+def test_connection_username_password_wrong_credentials() -> None:
+    environment = Environment(
+        uri="amqp://localhost:5672/",
+        username="guest",
+        password="wrongpassword",
+    )
+    connection = environment.connection()
+    with pytest.raises(ConnectionException):
+        connection.dial()


### PR DESCRIPTION
The only way to authenticate with a username and password was to embed the credentials directly in the connection URI (e.g. amqp://user:pass@host:5672/). This is inconvenient when credentials come from environment variables, secrets managers, or configuration files.

New optional username and password parameters are added to connection entry-points.