### PR TITLE
feat: add AmqpUri class for structured AMQP connection configuration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,3 +12,4 @@ Client examples
  - [RPC](./rpc) - Basic RPC example
  - [Rejected Messages](./rejected_messages/example_rejected_messages.py) - How to handle [rejected messages](https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#amqp-rejection-reason) with `AmqpMessageRejectedException` (RabbitMQ 4.3+)
  - [Quorum Queue SAC Notification](./quorum_queue_sac/example_quorum_queue_sac.py) - Quorum Queue Single Active Consumer state-change notifications via `QuorumConsumerOptions.sac_state_handler` (RabbitMQ 4.3+)
+ - [AmqpUri](./amqp_uri/example_amqp_uri.py) - Configure the connection with individual fields (host, port, user, password, vhost) using `AmqpUri` instead of a raw URI string

--- a/examples/amqp_uri/example_amqp_uri.py
+++ b/examples/amqp_uri/example_amqp_uri.py
@@ -44,9 +44,7 @@ class MyMessageHandler(AMQPMessagingHandler):
 
     def on_amqp_message(self, event: Event) -> None:
         print(
-            "received message: {}".format(
-                Converter.bytes_to_string(event.message.body)
-            )
+            "received message: {}".format(Converter.bytes_to_string(event.message.body))
         )
         self.delivery_context.accept(event)
         self._count += 1

--- a/examples/amqp_uri/example_amqp_uri.py
+++ b/examples/amqp_uri/example_amqp_uri.py
@@ -1,0 +1,142 @@
+# type: ignore
+"""
+AmqpUri example
+===============
+
+Demonstrates how to configure an AMQP connection using the ``AmqpUri``
+dataclass instead of a raw URI string.
+
+``AmqpUri`` lets you specify each part of the connection (schema, host, port,
+user, password, vhost) as a separate field with sensible defaults, so you
+never have to manually compose or parse a URI string.
+
+Exactly one of ``uri``, ``uris``, or ``amqp_uri`` must be passed to
+``Environment``.  Mixing them raises a ``ValueError``.
+
+Usage
+-----
+Start RabbitMQ first, then run:
+
+    python examples/amqp_uri/example_amqp_uri.py
+"""
+
+from rabbitmq_amqp_python_client import (
+    AddressHelper,
+    AMQPMessagingHandler,
+    AmqpUri,
+    Converter,
+    Environment,
+    Event,
+    Message,
+    OutcomeState,
+    QuorumQueueSpecification,
+)
+
+MESSAGES_TO_PUBLISH = 10
+QUEUE_NAME = "amqp-uri-example-queue"
+
+
+class MyMessageHandler(AMQPMessagingHandler):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._count = 0
+
+    def on_amqp_message(self, event: Event) -> None:
+        print(
+            "received message: {}".format(
+                Converter.bytes_to_string(event.message.body)
+            )
+        )
+        self.delivery_context.accept(event)
+        self._count += 1
+        if self._count == MESSAGES_TO_PUBLISH:
+            print("all messages received – stopping consumer")
+            raise SystemExit(0)
+
+    def on_connection_closed(self, event: Event) -> None:
+        print("connection closed")
+
+    def on_link_closed(self, event: Event) -> None:
+        print("link closed")
+
+
+def main() -> None:
+    # ------------------------------------------------------------------
+    # 1. All defaults – equivalent to "amqp://guest:guest@localhost:5672/"
+    # ------------------------------------------------------------------
+    default_uri = AmqpUri()
+    print(f"default AmqpUri  → {default_uri.to_uri()}")
+
+    # ------------------------------------------------------------------
+    # 2. Custom fields – only override what differs from the defaults
+    # ------------------------------------------------------------------
+    custom_uri = AmqpUri(
+        schema="amqp",
+        host="localhost",
+        port=5672,
+        user="guest",
+        password="guest",
+        vhost="/",
+    )
+    print(f"custom AmqpUri   → {custom_uri.to_uri()}")
+
+    # ------------------------------------------------------------------
+    # 3. Connect using amqp_uri=  (mutually exclusive with uri= / uris=)
+    # ------------------------------------------------------------------
+    print("\nconnecting to RabbitMQ via AmqpUri …")
+    environment = Environment(amqp_uri=AmqpUri())
+    connection = environment.connection()
+    connection.dial()
+    print("connected")
+
+    management = connection.management()
+
+    print(f"declaring queue '{QUEUE_NAME}'")
+    management.declare_queue(QuorumQueueSpecification(name=QUEUE_NAME))
+
+    addr_queue = AddressHelper.queue_address(QUEUE_NAME)
+
+    # ------------------------------------------------------------------
+    # 4. Publish messages
+    # ------------------------------------------------------------------
+    print(f"publishing {MESSAGES_TO_PUBLISH} messages")
+    publisher = connection.publisher(addr_queue)
+    for i in range(MESSAGES_TO_PUBLISH):
+        status = publisher.publish(
+            Message(body=Converter.string_to_bytes(f"message {i}"))
+        )
+        if status.remote_state == OutcomeState.ACCEPTED:
+            print(f"  message {i} accepted")
+        elif status.remote_state == OutcomeState.RELEASED:
+            print(f"  message {i} not routed")
+        elif status.remote_state == OutcomeState.REJECTED:
+            print(f"  message {i} rejected")
+    publisher.close()
+
+    # ------------------------------------------------------------------
+    # 5. Consume messages
+    # ------------------------------------------------------------------
+    print("consuming messages (press Ctrl+C to stop early) …")
+    consumer = connection.consumer(addr_queue, message_handler=MyMessageHandler())
+    try:
+        consumer.run()
+    except (KeyboardInterrupt, SystemExit):
+        pass
+
+    # ------------------------------------------------------------------
+    # 6. Clean up
+    # ------------------------------------------------------------------
+    print("\ncleaning up")
+    consumer.close()
+
+    management = connection.management()
+    management.delete_queue(QUEUE_NAME)
+    management.close()
+
+    environment.close()
+    print("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/amqp_uri/example_amqp_uri.py
+++ b/examples/amqp_uri/example_amqp_uri.py
@@ -69,7 +69,7 @@ def main() -> None:
     # ------------------------------------------------------------------
     # 2. Custom fields – only override what differs from the defaults
     # ------------------------------------------------------------------
-    custom_uri = AmqpUri(
+    uri = AmqpUri(
         schema="amqp",
         host="localhost",
         port=5672,
@@ -77,13 +77,13 @@ def main() -> None:
         password="guest",
         vhost="/",
     )
-    print(f"custom AmqpUri   → {custom_uri.to_uri()}")
+    print(f"custom AmqpUri   → {uri.to_uri()}")
 
     # ------------------------------------------------------------------
     # 3. Connect using amqp_uri=  (mutually exclusive with uri= / uris=)
     # ------------------------------------------------------------------
     print("\nconnecting to RabbitMQ via AmqpUri …")
-    environment = Environment(amqp_uri=AmqpUri())
+    environment = Environment(amqp_uri=uri)
     connection = environment.connection()
     connection.dial()
     print("connected")

--- a/rabbitmq_amqp_python_client/__init__.py
+++ b/rabbitmq_amqp_python_client/__init__.py
@@ -15,6 +15,7 @@ from .connection import Connection
 from .consumer import Consumer
 from .entities import (
     AbcConsumerOptions,
+    AmqpUri,
     ConsumerOptions,
     ConsumerSettleStrategy,
     ExchangeCustomSpecification,
@@ -73,6 +74,7 @@ del metadata
 OutcomeState = Disposition
 
 __all__ = [
+    "AmqpUri",
     "Connection",
     "Management",
     "ExchangeSpecification",

--- a/rabbitmq_amqp_python_client/asyncio/environment.py
+++ b/rabbitmq_amqp_python_client/asyncio/environment.py
@@ -4,7 +4,11 @@ import asyncio
 import logging
 from typing import Optional, Union
 
-from ..entities import OAuth2Options, RecoveryConfiguration
+from ..entities import (
+    AmqpUri,
+    OAuth2Options,
+    RecoveryConfiguration,
+)
 from ..ssl_configuration import (
     PosixSslConfigurationContext,
     WinSslConfigurationContext,
@@ -38,6 +42,8 @@ class AsyncEnvironment:
         uri: Optional[str] = None,
         # multi-node mode
         uris: Optional[list[str]] = None,
+        # structured single-node mode
+        amqp_uri: Optional[AmqpUri] = None,
         ssl_context: Union[
             PosixSslConfigurationContext, WinSslConfigurationContext, None
         ] = None,
@@ -47,25 +53,38 @@ class AsyncEnvironment:
         """
         Initialize AsyncEnvironment.
 
+        Exactly one of ``uri``, ``uris``, or ``amqp_uri`` must be provided.
+
         Args:
-            uri: Single node connection URI
-            uris: List of URIs for multi-node setup
-            ssl_context: SSL configuration for secure connections
-            oauth2_options: OAuth2 options for authentication
-            recovery_configuration: Configuration for connection recovery
+            uri: Single node connection URI string (e.g. ``"amqp://guest:guest@localhost:5672/"``).
+            uris: List of URI strings for multi-node setup.
+            amqp_uri: Structured single-node connection parameters as an :class:`AmqpUri`
+                instance.  Converted to a URI string internally.
+            ssl_context: SSL configuration for secure connections.
+            oauth2_options: OAuth2 options for authentication.
+            recovery_configuration: Configuration for connection recovery.
 
         Raises:
-            ValueError: If both 'uri' and 'uris' are specified or if neither is specified.
+            ValueError: If more than one of 'uri', 'uris', 'amqp_uri' is specified,
+                or if none is specified.
         """
-        if uri is not None and uris is not None:
+        set_count = sum(x is not None for x in [uri, uris, amqp_uri])
+        if set_count > 1:
             raise ValueError(
-                "Cannot specify both 'uri' and 'uris'. Choose one connection mode."
+                "Cannot specify more than one of 'uri', 'uris', or 'amqp_uri'. "
+                "Choose one connection mode."
             )
-        if uri is None and uris is None:
-            raise ValueError("Must specify either 'uri' or 'uris' for connection.")
+        if set_count == 0:
+            raise ValueError(
+                "Must specify exactly one of 'uri', 'uris', or 'amqp_uri' for connection."
+            )
 
-        self._uri = uri
-        self._uris = uris
+        if amqp_uri is not None:
+            self._uri: Optional[str] = amqp_uri.to_uri()
+            self._uris: Optional[list[str]] = None
+        else:
+            self._uri = uri
+            self._uris = uris
         self._ssl_context = ssl_context
         self._oauth2_options = oauth2_options
         self._recovery_configuration = recovery_configuration

--- a/rabbitmq_amqp_python_client/entities.py
+++ b/rabbitmq_amqp_python_client/entities.py
@@ -552,6 +552,48 @@ class RecoveryConfiguration:
 
 
 @dataclass
+class AmqpUri:
+    """
+    Configuration for an AMQP connection using individual fields.
+
+    Provides a structured alternative to a raw URI string, building the
+    connection URI from its component parts.
+
+    Attributes:
+        schema: The URI scheme (``"amqp"`` or ``"amqps"``). Defaults to ``"amqp"``.
+        host: The broker hostname or IP address. Defaults to ``"localhost"``.
+        port: The broker port. Defaults to ``5672``.
+        user: The authentication username. Defaults to ``"guest"``.
+        password: The authentication password. Defaults to ``"guest"``.
+        vhost: The target virtual host. Defaults to ``"/"``.
+    """
+
+    schema: str = "amqp"
+    host: str = "localhost"
+    port: int = 5672
+    user: str = "guest"
+    password: str = "guest"
+    vhost: str = "/"
+
+    def to_uri(self) -> str:
+        """
+        Build an AMQP URI string from the individual fields.
+
+        Returns:
+            str: A URI in the form ``schema://user:password@host:port/vhost``.
+        """
+        from urllib.parse import quote
+
+        user_enc = quote(self.user, safe="")
+        password_enc = quote(self.password, safe="")
+        if self.vhost == "/":
+            vhost_path = "/"
+        else:
+            vhost_path = "/" + quote(self.vhost, safe="")
+        return f"{self.schema}://{user_enc}:{password_enc}@{self.host}:{self.port}{vhost_path}"
+
+
+@dataclass
 class OAuth2Options:
     token: str
 

--- a/rabbitmq_amqp_python_client/environment.py
+++ b/rabbitmq_amqp_python_client/environment.py
@@ -9,7 +9,11 @@ from typing import (
 )
 
 from .connection import Connection
-from .entities import OAuth2Options, RecoveryConfiguration
+from .entities import (
+    AmqpUri,
+    OAuth2Options,
+    RecoveryConfiguration,
+)
 from .ssl_configuration import (
     PosixSslConfigurationContext,
     WinSslConfigurationContext,
@@ -38,6 +42,8 @@ class Environment:
         uri: Optional[str] = None,
         # multi-node mode
         uris: Optional[list[str]] = None,
+        # structured single-node mode
+        amqp_uri: Optional[AmqpUri] = None,
         ssl_context: Union[
             PosixSslConfigurationContext, WinSslConfigurationContext, None
         ] = None,
@@ -49,21 +55,33 @@ class Environment:
 
         Creates an empty list to track active connections.
 
-        Args:
-            uri: Single node connection URI
-            uris: List of URIs for multi-node setup
-            ssl_context: SSL configuration for secure connections
-            on_disconnection_handler: Callback for handling disconnection events
+        Exactly one of ``uri``, ``uris``, or ``amqp_uri`` must be provided.
 
+        Args:
+            uri: Single node connection URI string (e.g. ``"amqp://guest:guest@localhost:5672/"``).
+            uris: List of URI strings for multi-node setup.
+            amqp_uri: Structured single-node connection parameters as an :class:`AmqpUri`
+                instance.  Converted to a URI string internally.
+            ssl_context: SSL configuration for secure connections.
+            oauth2_options: OAuth2 authentication options.
+            recovery_configuration: Automatic reconnection configuration.
         """
-        if uri is not None and uris is not None:
+        set_count = sum(x is not None for x in [uri, uris, amqp_uri])
+        if set_count > 1:
             raise ValueError(
-                "Cannot specify both 'uri' and 'uris'. Choose one connection mode."
+                "Cannot specify more than one of 'uri', 'uris', or 'amqp_uri'. "
+                "Choose one connection mode."
             )
-        if uri is None and uris is None:
-            raise ValueError("Must specify either 'uri' or 'uris' for connection.")
-        self._uri = uri
-        self._uris = uris
+        if set_count == 0:
+            raise ValueError(
+                "Must specify exactly one of 'uri', 'uris', or 'amqp_uri' for connection."
+            )
+        if amqp_uri is not None:
+            self._uri: Optional[str] = amqp_uri.to_uri()
+            self._uris: Optional[list[str]] = None
+        else:
+            self._uri = uri
+            self._uris = uris
         self._ssl_context = ssl_context
         self._recovery_configuration = recovery_configuration
         self._connections: list[Connection] = []

--- a/tests/test_amqp_uri.py
+++ b/tests/test_amqp_uri.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for AmqpUri and the amqp_uri parameter on Environment / AsyncEnvironment.
+
+These tests are pure unit tests and do not require a running RabbitMQ broker.
+"""
+
+import pytest
+
+from rabbitmq_amqp_python_client import (
+    AmqpUri,
+    AsyncEnvironment,
+    Environment,
+)
+
+
+class TestAmqpUri:
+    """Tests for the AmqpUri dataclass and its to_uri() helper."""
+
+    def test_default_values_produce_standard_uri(self) -> None:
+        uri = AmqpUri()
+        assert uri.to_uri() == "amqp://guest:guest@localhost:5672/"
+
+    def test_custom_host(self) -> None:
+        uri = AmqpUri(host="rabbit.example.com")
+        assert uri.to_uri() == "amqp://guest:guest@rabbit.example.com:5672/"
+
+    def test_custom_port(self) -> None:
+        uri = AmqpUri(port=5673)
+        assert uri.to_uri() == "amqp://guest:guest@localhost:5673/"
+
+    def test_custom_schema_amqps(self) -> None:
+        uri = AmqpUri(schema="amqps", port=5671)
+        assert uri.to_uri() == "amqps://guest:guest@localhost:5671/"
+
+    def test_custom_user_and_password(self) -> None:
+        uri = AmqpUri(user="admin", password="s3cr3t")
+        assert uri.to_uri() == "amqp://admin:s3cr3t@localhost:5672/"
+
+    def test_default_vhost_slash_produces_single_slash_path(self) -> None:
+        uri = AmqpUri(vhost="/")
+        assert uri.to_uri().endswith("/")
+        # path component should be exactly "/"
+        assert uri.to_uri() == "amqp://guest:guest@localhost:5672/"
+
+    def test_custom_vhost(self) -> None:
+        uri = AmqpUri(vhost="production")
+        assert uri.to_uri() == "amqp://guest:guest@localhost:5672/production"
+
+    def test_special_chars_in_password_are_percent_encoded(self) -> None:
+        uri = AmqpUri(password="p@ss:w/ord")
+        result = uri.to_uri()
+        # "@", ":", "/" must be percent-encoded in the password
+        assert "p%40ss%3Aw%2Ford" in result
+
+    def test_special_chars_in_user_are_percent_encoded(self) -> None:
+        uri = AmqpUri(user="user@domain")
+        result = uri.to_uri()
+        assert "user%40domain" in result
+
+    def test_special_chars_in_vhost_are_percent_encoded(self) -> None:
+        uri = AmqpUri(vhost="my/vhost")
+        result = uri.to_uri()
+        assert result == "amqp://guest:guest@localhost:5672/my%2Fvhost"
+
+    def test_all_custom_fields(self) -> None:
+        uri = AmqpUri(
+            schema="amqps",
+            host="broker.internal",
+            port=5671,
+            user="alice",
+            password="wonderland",
+            vhost="staging",
+        )
+        assert uri.to_uri() == "amqps://alice:wonderland@broker.internal:5671/staging"
+
+    def test_dataclass_field_defaults(self) -> None:
+        uri = AmqpUri()
+        assert uri.schema == "amqp"
+        assert uri.host == "localhost"
+        assert uri.port == 5672
+        assert uri.user == "guest"
+        assert uri.password == "guest"
+        assert uri.vhost == "/"
+
+    def test_dataclass_fields_are_mutable(self) -> None:
+        uri = AmqpUri()
+        uri.host = "other-host"
+        uri.port = 9999
+        assert uri.to_uri() == "amqp://guest:guest@other-host:9999/"
+
+
+class TestEnvironmentAmqpUri:
+    """Tests for Environment.__init__ with the amqp_uri parameter."""
+
+    # ------------------------------------------------------------------
+    # Happy-path: each of the three modes accepted individually
+    # ------------------------------------------------------------------
+
+    def test_amqp_uri_is_accepted(self) -> None:
+        env = Environment(amqp_uri=AmqpUri())
+        assert env._uri == "amqp://guest:guest@localhost:5672/"
+        assert env._uris is None
+
+    def test_amqp_uri_converted_correctly(self) -> None:
+        amqp_uri = AmqpUri(host="mybroker", port=5673, user="bob", password="pw")
+        env = Environment(amqp_uri=amqp_uri)
+        assert env._uri == "amqp://bob:pw@mybroker:5673/"
+
+    def test_uri_string_still_accepted(self) -> None:
+        env = Environment(uri="amqp://guest:guest@localhost:5672/")
+        assert env._uri == "amqp://guest:guest@localhost:5672/"
+        assert env._uris is None
+
+    def test_uris_list_still_accepted(self) -> None:
+        uris = ["amqp://guest:guest@node1:5672/", "amqp://guest:guest@node2:5672/"]
+        env = Environment(uris=uris)
+        assert env._uris == uris
+        assert env._uri is None
+
+    # ------------------------------------------------------------------
+    # Error cases: more than one mode specified
+    # ------------------------------------------------------------------
+
+    def test_uri_and_amqp_uri_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            Environment(uri="amqp://guest:guest@localhost:5672/", amqp_uri=AmqpUri())
+
+    def test_uris_and_amqp_uri_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            Environment(uris=["amqp://guest:guest@localhost:5672/"], amqp_uri=AmqpUri())
+
+    def test_uri_and_uris_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            Environment(
+                uri="amqp://guest:guest@localhost:5672/",
+                uris=["amqp://guest:guest@localhost:5672/"],
+            )
+
+    def test_all_three_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            Environment(
+                uri="amqp://guest:guest@localhost:5672/",
+                uris=["amqp://guest:guest@localhost:5672/"],
+                amqp_uri=AmqpUri(),
+            )
+
+    def test_none_provided_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            Environment()
+
+    # ------------------------------------------------------------------
+    # Custom AmqpUri fields are reflected in the stored URI
+    # ------------------------------------------------------------------
+
+    def test_amqp_uri_vhost_reflected_in_stored_uri(self) -> None:
+        env = Environment(amqp_uri=AmqpUri(vhost="myvhost"))
+        assert env._uri == "amqp://guest:guest@localhost:5672/myvhost"
+
+    def test_amqp_uri_default_vhost_reflected_in_stored_uri(self) -> None:
+        env = Environment(amqp_uri=AmqpUri(vhost="/"))
+        assert env._uri == "amqp://guest:guest@localhost:5672/"
+
+
+class TestAsyncEnvironmentAmqpUri:
+    """Tests for AsyncEnvironment.__init__ with the amqp_uri parameter."""
+
+    # ------------------------------------------------------------------
+    # Happy-path
+    # ------------------------------------------------------------------
+
+    def test_amqp_uri_is_accepted(self) -> None:
+        env = AsyncEnvironment(amqp_uri=AmqpUri())
+        assert env._uri == "amqp://guest:guest@localhost:5672/"
+        assert env._uris is None
+
+    def test_amqp_uri_converted_correctly(self) -> None:
+        amqp_uri = AmqpUri(host="asyncbroker", port=5674, user="carol", password="xyz")
+        env = AsyncEnvironment(amqp_uri=amqp_uri)
+        assert env._uri == "amqp://carol:xyz@asyncbroker:5674/"
+
+    def test_uri_string_still_accepted(self) -> None:
+        env = AsyncEnvironment(uri="amqp://guest:guest@localhost:5672/")
+        assert env._uri == "amqp://guest:guest@localhost:5672/"
+        assert env._uris is None
+
+    def test_uris_list_still_accepted(self) -> None:
+        uris = ["amqp://guest:guest@node1:5672/", "amqp://guest:guest@node2:5672/"]
+        env = AsyncEnvironment(uris=uris)
+        assert env._uris == uris
+        assert env._uri is None
+
+    # ------------------------------------------------------------------
+    # Error cases
+    # ------------------------------------------------------------------
+
+    def test_uri_and_amqp_uri_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            AsyncEnvironment(
+                uri="amqp://guest:guest@localhost:5672/", amqp_uri=AmqpUri()
+            )
+
+    def test_uris_and_amqp_uri_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            AsyncEnvironment(
+                uris=["amqp://guest:guest@localhost:5672/"], amqp_uri=AmqpUri()
+            )
+
+    def test_uri_and_uris_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            AsyncEnvironment(
+                uri="amqp://guest:guest@localhost:5672/",
+                uris=["amqp://guest:guest@localhost:5672/"],
+            )
+
+    def test_all_three_together_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            AsyncEnvironment(
+                uri="amqp://guest:guest@localhost:5672/",
+                uris=["amqp://guest:guest@localhost:5672/"],
+                amqp_uri=AmqpUri(),
+            )
+
+    def test_none_provided_raises(self) -> None:
+        with pytest.raises(ValueError, match="amqp_uri"):
+            AsyncEnvironment()
+
+    # ------------------------------------------------------------------
+    # Custom AmqpUri fields
+    # ------------------------------------------------------------------
+
+    def test_amqp_uri_vhost_reflected_in_stored_uri(self) -> None:
+        env = AsyncEnvironment(amqp_uri=AmqpUri(vhost="staging"))
+        assert env._uri == "amqp://guest:guest@localhost:5672/staging"
+
+    def test_amqp_uri_default_vhost_reflected_in_stored_uri(self) -> None:
+        env = AsyncEnvironment(amqp_uri=AmqpUri(vhost="/"))
+        assert env._uri == "amqp://guest:guest@localhost:5672/"


### PR DESCRIPTION
Introduces AmqpUri, a dataclass that lets callers configure a connection using individual fields (schema, host, port, user, password, vhost) with sensible defaults, instead of composing a raw URI string by hand.

Environment and AsyncEnvironment now accept amqp_uri as a third, mutually exclusive alternative to uri and uris. Special characters in user, password, and vhost are percent-encoded automatically via urllib.parse.quote.

Also adds unit tests (tests/test_amqp_uri.py) and a runnable example (examples/amqp_uri/example_amqp_uri.py) with a matching README entry.