### PR TITLE
Enforce peer verification for SSL connections.

### DIFF
--- a/examples/tls/tls_example.py
+++ b/examples/tls/tls_example.py
@@ -84,11 +84,11 @@ def main() -> None:
     exchange_name = "tls-test-exchange"
     queue_name = "tls-example-queue"
     routing_key = "tls-routing-key"
-    ca_p12_store = ".ci/certs/ca.p12"
-    ca_cert_file = ".ci/certs/ca_certificate.pem"
-    client_cert = ".ci/certs/client_localhost_certificate.pem"
-    client_key = ".ci/certs/client_localhost_key.pem"
-    client_p12_store = ".ci/certs/client_localhost.p12"
+    ca_p12_store = "../../.ci/certs/ca.p12"
+    ca_cert_file = "../../.ci/certs/ca_certificate.pem"
+    client_cert = "../../.ci/certs/client_localhost_certificate.pem"
+    client_key = "../../.ci/certs/client_localhost_key.pem"
+    client_p12_store = "../../.ci/certs/client_localhost.p12"
     uri = "amqps://guest:guest@localhost:5671/"
 
     if sys.platform == "win32":

--- a/examples/tls/tls_example_async.py
+++ b/examples/tls/tls_example_async.py
@@ -77,11 +77,11 @@ async def main() -> None:
     exchange_name = "tls-test-exchange"
     queue_name = "tls-example-queue"
     routing_key = "tls-routing-key"
-    ca_p12_store = ".ci/certs/ca.p12"
-    ca_cert_file = ".ci/certs/ca_certificate.pem"
-    client_cert = ".ci/certs/client_localhost_certificate.pem"
-    client_key = ".ci/certs/client_localhost_key.pem"
-    client_p12_store = ".ci/certs/client_localhost.p12"
+    ca_p12_store = "../../.ci/certs/ca.p12"
+    ca_cert_file = "../../.ci/certs/ca_certificate.pem"
+    client_cert = "../../.ci/certs/client_localhost_certificate.pem"
+    client_key = "../../.ci/certs/client_localhost_key.pem"
+    client_p12_store = "../../.ci/certs/client_localhost.p12"
     uri = "amqps://guest:guest@localhost:5671/"
 
     environment = None

--- a/rabbitmq_amqp_python_client/connection.py
+++ b/rabbitmq_amqp_python_client/connection.py
@@ -274,6 +274,9 @@ class Connection:
             else:
                 typing_extensions.assert_never(self._conf_ssl_context)
             self._ssl_domain.set_trusted_ca_db(ca_cert)
+            self._ssl_domain.set_peer_authentication(
+                SSLDomain.VERIFY_PEER_NAME, ca_cert
+            )
 
             # for mutual authentication
             if self._conf_ssl_context.client_cert is not None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,10 +1,14 @@
+import os
+import tempfile
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from rabbitmq_amqp_python_client import (
+    Connection,
     ConnectionClosed,
     Environment,
     PKCS12Store,
@@ -17,6 +21,9 @@ from rabbitmq_amqp_python_client import (
 )
 from rabbitmq_amqp_python_client.qpid.proton import (
     ConnectionException,
+)
+from rabbitmq_amqp_python_client.qpid.proton._transport import (
+    SSLDomain,
 )
 
 from .http_requests import (
@@ -272,3 +279,33 @@ def test_connection_vhost_not_exists() -> None:
         exception = True
 
     assert exception is True
+
+
+def test_connection_ssl_explicit_peer_verification() -> None:
+    with tempfile.NamedTemporaryFile(suffix=".pem", delete=False) as f:
+        ca_path = f.name
+
+    try:
+        ssl_ctx = PosixSslConfigurationContext(ca_cert=ca_path)
+        conn = Connection(
+            uri="amqps://guest:guest@localhost:5671/", ssl_context=ssl_ctx
+        )
+
+        mock_domain = MagicMock(spec=SSLDomain)
+
+        with patch(
+            "rabbitmq_amqp_python_client.connection.SSLDomain"
+        ) as mock_ssl_domain_cls:
+            mock_ssl_domain_cls.return_value = mock_domain
+            mock_ssl_domain_cls.VERIFY_PEER_NAME = SSLDomain.VERIFY_PEER_NAME
+            mock_ssl_domain_cls.MODE_CLIENT = SSLDomain.MODE_CLIENT
+
+            with patch.object(conn, "_open_connections"):
+                conn.dial()
+
+        mock_domain.set_trusted_ca_db.assert_called_once_with(ca_path)
+        mock_domain.set_peer_authentication.assert_called_once_with(
+            SSLDomain.VERIFY_PEER_NAME, ca_path
+        )
+    finally:
+        os.unlink(ca_path)


### PR DESCRIPTION
Previously, SSL connections relied on the underlying client enforcing peer verification. Peer verification is now explicitly enforced, protecting against any potential future changes in underlying client behavior.

[ai-assisted=yes]