### PR TITLE
feat: redact password in log statement

### DIFF
--- a/rabbitmq_amqp_python_client/qpid/proton/_reactor.py
+++ b/rabbitmq_amqp_python_client/qpid/proton/_reactor.py
@@ -1105,7 +1105,10 @@ class _Connector(Handler):
         else:
             connection.hostname = url.host
 
-        _logger.info("Connecting to %r..." % url)
+        log_url = Url(url)
+        if log_url.password:
+            log_url.password = "********"
+        _logger.info("Connecting to %r..." % log_url)
 
         transport = Transport()
         if self.sasl_enabled:


### PR DESCRIPTION
Not sure why this hasn't popped up before, neither here or upstream.
(I'm trying to file a issue for this upstream, as this appears to be the case across all of qpid-proton.)